### PR TITLE
Add PMC list

### DIFF
--- a/PMC
+++ b/PMC
@@ -1,0 +1,5 @@
+Chris Odom;FellowTraveler
+Cameron Garnham;da2ce7
+Filip Gospodinov;toxeus
+Tommy Back;murrekatt
+Lucas Betschart;lclc

--- a/committers
+++ b/committers
@@ -1,0 +1,7 @@
+Marko Bencun;benma
+Martin Hamrle;mhamrle
+Otto Allmendinger;OttoAllmendinger
+Justus Ranvier;justusranvier
+Jonathan Rumion;yamamushi
+Jeff Weiss;weissjeffm
+Darragh Grealish;grealish


### PR DESCRIPTION
Adds a list of the current PMC members so changes are recorded in git and bots can easily get it from here (e.g. for a voting bot).

**Regarding committers:**

From our MeritocraticGovernanceVoting.md document:
"However, only some members have binding votes for the purposes of decision making; these are the committers and/or the members of the Project Management Committee."

List of potential committers (looking at recent contributions in source code, community work, documentation etc.):
Marko Bencun;benma
Martin Hamrle;mhamrle
Otto Allmendinger;OttoAllmendinger
Justus Ranvier;justusranvier
Jonathan Rumion;yamamushi
Jeff Weiss;weissjeffm
Darragh Grealish;grealish (if he makes the CI available for the public :P)

What do you think? Did I miss somebody?
Tell me if somebody doesn't want to be listed with his real name. I'll create a new PR with a file like this.

If Monetas makes https://github.com/monetas/protocol-docs open source (the license) I'd also add haarts and paulhession.

Monetas will have a majority in every voting, which I think should be no problem since I expect from everybody to vote for what he thinks is the best for the project and not just by what orders he gets from the management.

I'll also consider stepping down as PMC, depending on the amount of time I can put into OT in the future.

Comment on this please: @toxeus @da2ce7 @FellowTraveler @murrekatt @benma @mhamrle @OttoAllmendinger @justusranvier @yamamushi @weissjeffm @grealish
If I get no reaction I consider it as accepted.
